### PR TITLE
Make use transactions cache again

### DIFF
--- a/src/stores/transactions.ts
+++ b/src/stores/transactions.ts
@@ -41,7 +41,7 @@ export const useTransactionsStore = defineStore('transactions', {
         memoOffset: number;
         transactionsTableLimit: number;
         transactionsTableOffset: number;
-        transactionsByOffset: Record<number, Array<Transaction>>; // New state property
+        transactionsByOffset: Record<number, Array<Transaction>>;
     } => ({
         selectedDay: '',
         selectedMonth: '',
@@ -71,7 +71,7 @@ export const useTransactionsStore = defineStore('transactions', {
         transactionsTableLimit: 100,
         transactionsTableOffset: 0,
         transactions: [],
-        transactionsByOffset: {}, // Initialize as empty object
+        transactionsByOffset: {},
     }),
     getters: {
         getSelectedDay: (state) => state.selectedDay,
@@ -101,13 +101,10 @@ export const useTransactionsStore = defineStore('transactions', {
         getTransactionsTableOffset: (state) => state.transactionsTableOffset,
         getDaysForSelectedWeek: (state) => state.daysForSelectedWeek,
         getTransactions: (state) => state.transactions,
-
-        // New getters
         getTransactionsByOffset: (state) => (offset: number) => {
             return state.transactionsByOffset[offset] || [];
         },
         getAllTransactions: (state) => {
-            // Flatten all transactions stored by offset
             return Object.values(state.transactionsByOffset).flat();
         },
     },

--- a/src/stores/transactions.ts
+++ b/src/stores/transactions.ts
@@ -1,37 +1,47 @@
-import {defineStore} from 'pinia'
-import type {Memo, MJSummary, MonthYear, OFSummary, Summaries, WeekYear, DayYear, Year, Transaction} from "@types";
+import { defineStore } from 'pinia';
+import type {
+    Memo,
+    MJSummary,
+    MonthYear,
+    OFSummary,
+    Summaries,
+    WeekYear,
+    DayYear,
+    Year,
+    Transaction,
+} from '@types';
 
 export const useTransactionsStore = defineStore('transactions', {
-
     state: (): {
-        selectedDay: string,
-        selectedWeek: string,
-        selectedMonth: string,
-        selectedYear: string,
-        selectedMemo: string,
-        selectedType: string,
-        selectedBudgetCategory: string,
-        days: Array<DayYear>,
-        daysForSelectedWeek: Array<string>,
-        weeksForSelectedMonth: Array<string>,
-        weeks: Array<WeekYear>,
-        months: Array<MonthYear>,
-        memos: Array<Memo>,
-        years: Array<Year>,
-        OFSummaries: Array<OFSummary>,
-        MJSummaries: Array<MJSummary>,
-        daysSummaries: Array<Summaries>,
-        weeksSummaries: Array<Summaries>,
-        monthsSummaries: Array<Summaries>,
-        transactions: Array<Transaction>,
-        transactionsCurrentPage: number,
-        transactionsPageSize: number,
-        filter: Record<string, string>,
-        sort: { prop: string, order: string },
-        memoLimit: number,
-        memoOffset: number,
-        transactionsTableLimit: number,
-        transactionsTableOffset: number,
+        selectedDay: string;
+        selectedWeek: string;
+        selectedMonth: string;
+        selectedYear: string;
+        selectedMemo: string;
+        selectedType: string;
+        selectedBudgetCategory: string;
+        days: Array<DayYear>;
+        daysForSelectedWeek: Array<string>;
+        weeksForSelectedMonth: Array<string>;
+        weeks: Array<WeekYear>;
+        months: Array<MonthYear>;
+        memos: Array<Memo>;
+        years: Array<Year>;
+        OFSummaries: Array<OFSummary>;
+        MJSummaries: Array<MJSummary>;
+        daysSummaries: Array<Summaries>;
+        weeksSummaries: Array<Summaries>;
+        monthsSummaries: Array<Summaries>;
+        transactions: Array<Transaction>;
+        transactionsCurrentPage: number;
+        transactionsPageSize: number;
+        filter: Record<string, string>;
+        sort: { prop: string; order: string };
+        memoLimit: number;
+        memoOffset: number;
+        transactionsTableLimit: number;
+        transactionsTableOffset: number;
+        transactionsByOffset: Record<number, Array<Transaction>>; // New state property
     } => ({
         selectedDay: '',
         selectedMonth: '',
@@ -55,150 +65,106 @@ export const useTransactionsStore = defineStore('transactions', {
         transactionsCurrentPage: 1,
         transactionsPageSize: 100,
         filter: {},
-        sort: {prop: '', order: ''},
+        sort: { prop: '', order: '' },
         memoLimit: 100,
         memoOffset: 0,
         transactionsTableLimit: 100,
         transactionsTableOffset: 0,
-        transactions: []
+        transactions: [],
+        transactionsByOffset: {}, // Initialize as empty object
     }),
     getters: {
-        getSelectedDay: (state) => {
-            return state.selectedDay
+        getSelectedDay: (state) => state.selectedDay,
+        getSelectedMonth: (state) => state.selectedMonth,
+        getSelectedMemo: (state) => state.selectedMemo,
+        getSelectedWeek: (state) => state.selectedWeek,
+        getSelectedYear: (state) => state.selectedYear,
+        getSelectedType: (state) => state.selectedType,
+        getDays: (state) => state.days,
+        getWeeks: (state) => state.weeks,
+        getMonths: (state) => state.months,
+        getYears: (state) => state.years,
+        getMemos: (state) => state.memos,
+        getOFSummaries: (state) => state.OFSummaries,
+        getMJSummaries: (state) => state.MJSummaries,
+        getDaysSummaries: (state) => state.daysSummaries,
+        getWeeksSummaries: (state) => state.weeksSummaries,
+        getMonthsSummaries: (state) => state.monthsSummaries,
+        getTransactionsCurrentPage: (state) => state.transactionsCurrentPage,
+        getTransactionsPageSize: (state) => state.transactionsPageSize,
+        getFilter: (state) => state.filter,
+        getSort: (state) => state.sort,
+        getMemoLimit: (state) => state.memoLimit,
+        getMemoOffset: (state) => state.memoOffset,
+        getSelectedBudgetCategory: (state) => state.selectedBudgetCategory,
+        getTransactionsTableLimit: (state) => state.transactionsTableLimit,
+        getTransactionsTableOffset: (state) => state.transactionsTableOffset,
+        getDaysForSelectedWeek: (state) => state.daysForSelectedWeek,
+        getTransactions: (state) => state.transactions,
+
+        // New getters
+        getTransactionsByOffset: (state) => (offset: number) => {
+            return state.transactionsByOffset[offset] || [];
         },
-        getSelectedMonth: (state) => {
-            return state.selectedMonth
+        getAllTransactions: (state) => {
+            // Flatten all transactions stored by offset
+            return Object.values(state.transactionsByOffset).flat();
         },
-        getSelectedMemo: (state) => {
-            return state.selectedMemo
-        },
-        getSelectedWeek: (state) => {
-            return state.selectedWeek
-        },
-        getSelectedYear: (state) => {
-            return state.selectedYear
-        },
-        getSelectedType: (state) => {
-            return state.selectedType
-        },
-        getDays: (state) => {
-            return state.days
-        },
-        getWeeks: (state) => {
-            return state.weeks
-        },
-        getMonths: (state) => {
-            return state.months
-        },
-        getYears: (state) => {
-            return state.years
-        },
-        getMemos: (state) => {
-            return state.memos
-        },
-        getOFSummaries: (state) => {
-            return state.OFSummaries
-        },
-        getMJSummaries: (state) => {
-            return state.MJSummaries
-        },
-        getDaysSummaries: (state) => {
-            return state.daysSummaries
-        },
-        getWeeksSummaries: (state) => {
-            return state.weeksSummaries
-        },
-        getMonthsSummaries: (state) => {
-            return state.monthsSummaries
-        },
-        getTransactionsCurrentPage: (state) => {
-            return state.transactionsCurrentPage
-        },
-        getTransactionsPageSize: (state) => {
-            return state.transactionsPageSize
-        },
-        getFilter: (state) => {
-            return state.filter
-        },
-        getSort: (state) => {
-            return state.sort
-        },
-        getMemoLimit: (state) => {
-            return state.memoLimit
-        },
-        getMemoOffset: (state) => {
-            return state.memoOffset
-        },
-        getSelectedBudgetCategory: (state) => {
-            return state.selectedBudgetCategory
-        },
-        getTransactionsTableLimit: (state) => {
-            return state.transactionsTableLimit
-        },
-        getTransactionsTableOffset: (state) => {
-            return state.transactionsTableOffset
-        },
-        getDaysForSelectedWeek: (state) => {
-            return state.daysForSelectedWeek
-        },
-        getTransactions: (state) => {
-            return state.transactions
-        }
     },
     actions: {
         setSelectedDay(selectedDay: string) {
-            this.selectedDay = selectedDay
+            this.selectedDay = selectedDay;
         },
         setSelectedMonth(selectedMonth: string) {
-            this.selectedMonth = selectedMonth
+            this.selectedMonth = selectedMonth;
         },
         setSelectedMemo(selectedMemo: string) {
-            this.selectedMemo = selectedMemo
+            this.selectedMemo = selectedMemo;
         },
         setSelectedWeek(selectedWeek: string) {
-            this.selectedWeek = selectedWeek
+            this.selectedWeek = selectedWeek;
         },
         setSelectedYear(selectedYear: string) {
-            this.selectedYear = selectedYear
+            this.selectedYear = selectedYear;
         },
         setSelectedType(selectedType: string) {
-            this.selectedType = selectedType
+            this.selectedType = selectedType;
         },
         setDays(days: Array<DayYear>) {
-            this.days = days
+            this.days = days;
         },
         setMemos(memos: Array<Memo>) {
-            this.memos = memos
+            this.memos = memos;
         },
         setMemoLimit(limit: number) {
-            this.memoLimit = limit
+            this.memoLimit = limit;
         },
         setMemoOffset(offset: number) {
-            this.memoOffset = offset
+            this.memoOffset = offset;
         },
         setMonths(months: Array<MonthYear>) {
-            this.months = months
+            this.months = months;
         },
         setWeeks(weeks: Array<WeekYear>) {
-            this.weeks = weeks
+            this.weeks = weeks;
         },
         setYears(years: Array<Year>) {
-            this.years = years
+            this.years = years;
         },
         setOFSummaries(summaries: Array<OFSummary>) {
-            this.OFSummaries = summaries
+            this.OFSummaries = summaries;
         },
         setMJSummaries(summaries: Array<MJSummary>) {
-            this.MJSummaries = summaries
+            this.MJSummaries = summaries;
         },
         setDaysSummaries(summaries: Array<Summaries>) {
-            this.daysSummaries = summaries
+            this.daysSummaries = summaries;
         },
         setWeeksSummaries(summaries: Array<Summaries>) {
-            this.weeksSummaries = summaries
+            this.weeksSummaries = summaries;
         },
         setMonthsSummaries(summaries: Array<Summaries>) {
-            this.monthsSummaries = summaries
+            this.monthsSummaries = summaries;
         },
         updateTransactionsCurrentPage(currentPage: number) {
             this.transactionsCurrentPage = currentPage;
@@ -209,7 +175,7 @@ export const useTransactionsStore = defineStore('transactions', {
         updateFilter(filter: Record<string, string>) {
             this.filter = filter;
         },
-        updateSort(sort: { prop: string, order: string }) {
+        updateSort(sort: { prop: string; order: string }) {
             this.sort = sort;
         },
         setSelectedBudgetCategory(selectedBudgetCategory: string) {
@@ -229,7 +195,12 @@ export const useTransactionsStore = defineStore('transactions', {
         },
         setTransactions(transactions: Array<Transaction>) {
             this.transactions = transactions;
-        }
-    }
-
-})
+        },
+        setTransactionsByOffset(offset: number, transactions: Array<Transaction>) {
+            this.transactionsByOffset[offset] = transactions;
+        },
+        clearTransactionsByOffset() {
+            this.transactionsByOffset = {};
+        },
+    },
+});


### PR DESCRIPTION
- added caching back to the useTransactions hook, after it was accidentally removed during the transition to `useInfiniteQuery`