### PR TITLE
DRYing out API methods with an httpClient

### DIFF
--- a/src/api/address/fetchAddress.ts
+++ b/src/api/address/fetchAddress.ts
@@ -14,7 +14,7 @@ export async function fetchAddress(id: string, fetchURL?: string) {
         throw Error('url is not valid');
     }
 
-    return await axios.get(`${fetchURL}/address-geocoder/${id}`)
+    return await axios.get(`/address-geocoder/${id}`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/hooks/transactions/useSummaries.ts
+++ b/src/api/hooks/transactions/useSummaries.ts
@@ -6,7 +6,7 @@ import {getDateTypeAndValue} from '@components/transactions/getDateTypeAndValue'
 import {computed} from "vue";
 import {useTransactionsStore} from "@stores/transactions";
 
-export default function useSummaries(): UseQueryReturnType<Summaries[], Error> {
+export default function useSummaries() {
 
     const {dateType, selectedValue} = getDateTypeAndValue();
     const store = useTransactionsStore();

--- a/src/api/httpClient.ts
+++ b/src/api/httpClient.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const httpClient = axios.create({
+    baseURL: import.meta.env.VITE_APIGATEWAY_URL
+})

--- a/src/api/transactions/fetchBudgetCategories.ts
+++ b/src/api/transactions/fetchBudgetCategories.ts
@@ -1,14 +1,7 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchBudgetCategories() {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-budget-categories`)
+    return await httpClient.get(`/transactions/get-budget-categories`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchCarBudget.ts
+++ b/src/api/transactions/fetchCarBudget.ts
@@ -1,17 +1,10 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {CarBudget, TimeframeType} from "@types";
+import {httpClient} from "@api/httpClient";
 
 // returns a CarBudget for a given date, for a given timeFrame
 export default async function fetchCarBudget(date: Date | null, timeFrame: TimeframeType): Promise<CarBudget> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO instead of a path, pass query params to transactions route, budgetCategory
-    return await axios.get(`${fetchURL}/transactions/get-car-budget`, {
+    return await httpClient.get(`/transactions/get-car-budget`, {
         params: {
             timeFrame: timeFrame,
             date: date

--- a/src/api/transactions/fetchDailyAmountDebitForInterval.ts
+++ b/src/api/transactions/fetchDailyAmountDebitForInterval.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {DailyInterval} from "@types";
 
 export async function fetchDailyAmountDebitForInterval(interval?: string, startDate?: string) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios
-        .get<Array<DailyInterval>>(`${fetchURL}/transactions/get-daily-total-amount-debit`, {
+    return await httpClient
+        .get<Array<DailyInterval>>(`/transactions/get-daily-total-amount-debit`, {
             params: {
                 interval,
                 startDate

--- a/src/api/transactions/fetchDaySummary.ts
+++ b/src/api/transactions/fetchDaySummary.ts
@@ -9,7 +9,7 @@ export async function fetchDaySummary(day: string): Promise<DaySummary[]> {
         throw Error('url is not valid');
     }
 
-    return await axios.get(`${fetchURL}/transactions/get-day-summary`, {
+    return await axios.get(`/transactions/get-day-summary`, {
         params: {
             day
         }

--- a/src/api/transactions/fetchDays.ts
+++ b/src/api/transactions/fetchDays.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {DayYear} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchDays(): Promise<Array<DayYear>> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-days`)
+    return await httpClient.get(`/transactions/get-days`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchDaysOfWeek.ts
+++ b/src/api/transactions/fetchDaysOfWeek.ts
@@ -1,14 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
+
 
 export async function fetchDaysOfWeek(weekString: string) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-days-of-week`, {
+    return await httpClient.get(`/transactions/get-days-of-week`, {
         params: {
             week: weekString
         }

--- a/src/api/transactions/fetchDescriptions.ts
+++ b/src/api/transactions/fetchDescriptions.ts
@@ -8,7 +8,7 @@ export async function fetchDescriptions(): Promise<Array<string>> {
         throw Error('url is not valid');
     }
 
-    return await axios.get(`${fetchURL}/transactions/descriptions`)
+    return await axios.get(`/transactions/descriptions`)
         .then((res) => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchIsIntervalGreaterThanOIdestDate.ts
+++ b/src/api/transactions/fetchIsIntervalGreaterThanOIdestDate.ts
@@ -8,7 +8,7 @@ export async function fetchIsIntervalGreaterThanOldestDate(interval: string): Pr
         throw Error('url is not valid');
     }
 
-    return await axios.get(`${fetchURL}/transactions/is-interval-greater-than-oldest-date`, {
+    return await axios.get(`/transactions/is-interval-greater-than-oldest-date`, {
         params: {
             interval
         }

--- a/src/api/transactions/fetchMJAmountDebit.ts
+++ b/src/api/transactions/fetchMJAmountDebit.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {MJSummary} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchMJAmountDebit(timeFrame: string, date?: Date | null | undefined): Promise<MJSummary> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO instead of a path, pass query params to transactions route, budgetCategory
-    return await axios.get(`${fetchURL}/transactions/get-mj-amount-debit`, {
+    return await httpClient.get(`/transactions/get-mj-amount-debit`, {
         params: {
             timeFrame: timeFrame,
             date: date ? date?.toISOString().split('T')[0] : null

--- a/src/api/transactions/fetchMemo.ts
+++ b/src/api/transactions/fetchMemo.ts
@@ -1,19 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Memo} from "@types";
+import {httpClient} from "@api/httpClient";
 
-export async function fetchMemo(memo: Memo['name']): Promise<Memo> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-memo`, {
-        params: {
-            memo: memo
-        }
-    })
+export async function fetchMemo(memoId: Memo['id']): Promise<Memo> {
+    return await httpClient.get(`/memos/${memoId}`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchMemoBudgetCategory.ts
+++ b/src/api/transactions/fetchMemoBudgetCategory.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {Memo, BudgetCategory} from "@types";
 
 // TODO remove: it's redundant. And, remove route from API Gateway.
 export async function fetchMemoBudgetCategory(memo: Memo['name']): Promise<BudgetCategory> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-memo-budget-category`, {
+    return await httpClient.get(`/transactions/get-memo-budget-category`, {
         params: {
             memo: memo
         }

--- a/src/api/transactions/fetchMemoSummary.ts
+++ b/src/api/transactions/fetchMemoSummary.ts
@@ -1,19 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Memo, MemoSummary} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchMemoSummary(memo: Memo['name']): Promise<MemoSummary> {
-    console.log('memo:', memo);
-    console.log('typeof memo:', typeof memo);
-
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO refactor, remove redundant path: /get-memo-summary, use 'transactions/summary?memo=${memo}'
-    return await axios.get(`${fetchURL}/transactions/get-memo-summary`, {
+    return await httpClient.get(`/transactions/get-memo-summary`, {
         params: {
             memo
         }

--- a/src/api/transactions/fetchMemoTransactions.ts
+++ b/src/api/transactions/fetchMemoTransactions.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Transaction, Memo} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchMemoTransactions(memoName: Memo['name']): Promise<Transaction> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-transactions`, {
+    return await httpClient.get(`/transactions/get-transactions`, {
         params: {
             memo: memoName
         }

--- a/src/api/transactions/fetchMemos.ts
+++ b/src/api/transactions/fetchMemos.ts
@@ -1,20 +1,11 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Memo} from "@types";
 import {parseDateMMYYYY} from "@api/helpers/parseDateMMYYYY";
+import {httpClient} from "@api/httpClient";
 
 // TODO: update to account for selectedYear, selectedWeek, selectedDay — add timeframe parameter
 export async function fetchMemos(date?: string): Promise<Array<Memo>> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    // Convert the date string to a Date object
     const dateObj = date ? parseDateMMYYYY(date) : null;
-
-    return await axios.get(`${fetchURL}/transactions/get-memos`, {
+    return await httpClient.get(`/transactions/get-memos`, {
         params: {
             date: dateObj ? dateObj?.toISOString() : undefined
         }

--- a/src/api/transactions/fetchMemosCount.ts
+++ b/src/api/transactions/fetchMemosCount.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
-
 // TODO remove, since it's not being used
+import {httpClient} from "@api/httpClient";
+
 export async function fetchMemosCount(timeFrame?: string | undefined, date?: Date | null | undefined, distinct?: boolean | undefined): Promise<number> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/memos/get-memos-count`, {
+    return await httpClient.get(`/memos/get-memos-count`, {
         params: {
             timeFrame: timeFrame,
             date: date,

--- a/src/api/transactions/fetchMonthSummary.ts
+++ b/src/api/transactions/fetchMonthSummary.ts
@@ -1,17 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {MonthSummary} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchMonthSummary(month: string): Promise<MonthSummary[]> {
-
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios
-        .get(`${fetchURL}/transactions/get-month-summary`, {
+    return await httpClient
+        .get(`/transactions/get-month-summary`, {
             params: {
                 month
             }

--- a/src/api/transactions/fetchMonths.ts
+++ b/src/api/transactions/fetchMonths.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {MonthYear} from "@types";
 
 export async function fetchMonths(): Promise<Array<MonthYear>> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-months`)
+    return await httpClient.get(`/transactions/get-months`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchOFAmountDebit.ts
+++ b/src/api/transactions/fetchOFAmountDebit.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {OFSummaryTypeBase} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchOFAmountDebit(timeFrame: string, date?: Date | null | undefined): Promise<OFSummaryTypeBase> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO instead of a path, pass query params to transactions route, budgetCategory
-    return await axios.get(`${fetchURL}/transactions/get-of-amount-debit`, {
+    return await httpClient.get(`/transactions/get-of-amount-debit`, {
         params: {
             timeFrame: timeFrame,
             date: date ? date?.toISOString().split('T')[0] : null

--- a/src/api/transactions/fetchOldestTransactionDate.ts
+++ b/src/api/transactions/fetchOldestTransactionDate.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
 export default async function fetchOldestTransactionDate() {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO instead of hitting this route, pass query params to transactions route
-    return await axios
-        .get<string>(`${fetchURL}/transactions/get-oldest-transaction-date`)
+    return await httpClient
+        .get<string>(`/transactions/get-oldest-transaction-date`)
         .then((res) => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchSumAmountDebitByDate.ts
+++ b/src/api/transactions/fetchSumAmountDebitByDate.ts
@@ -1,14 +1,7 @@
-import axios from "axios";
-import { isValidURL } from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchSumAmountDebitByDate(timeFrame: string, date: Date | null | undefined) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-sum-amount-debit-by-date`, {
+    return await httpClient.get(`/transactions/get-sum-amount-debit-by-date`, {
         params: {
             timeFrame,
             date: date?.toISOString().split('T')[0]

--- a/src/api/transactions/fetchSummaries.ts
+++ b/src/api/transactions/fetchSummaries.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Summaries} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchSummaries(timeFrame: string) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get<Array<Summaries>>(`${fetchURL}/transactions/get-summaries`, {
+    return await httpClient.get<Array<Summaries>>(`/transactions/get-summaries`, {
         params: {
             timeFrame
         },

--- a/src/api/transactions/fetchTransaction.ts
+++ b/src/api/transactions/fetchTransaction.ts
@@ -1,22 +1,11 @@
-import axios from "axios";
 import type {Transaction} from "@types";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
-export const fetchTransaction = async (transactionNumber: string): Promise<Transaction> => {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    // TODO replace with 'transactions/{transactionNumber}'
-    return await axios.get(`${fetchURL}/transactions/get-transaction`, {
-        params: {
-            transactionNumber: transactionNumber
-        },
-    })
+export const fetchTransaction = async (transactionId: Transaction['id']): Promise<Transaction> => {
+    return await httpClient.get(`/transactions/${transactionId}`)
         .then((res) => res.data)
         .catch((err: Error) => {
             console.error('err:', err);
+            throw new Error("Failed to fetch transaction. Please try again later.");
         });
 };

--- a/src/api/transactions/fetchTransactions.ts
+++ b/src/api/transactions/fetchTransactions.ts
@@ -1,7 +1,5 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {TimeframeType, Memo} from "@types";
-
 
 export async function fetchTransactions(queryParams: {
     date: Date;
@@ -12,14 +10,8 @@ export async function fetchTransactions(queryParams: {
 }) {
     const {date, limit, offset, timeFrame, memo} = queryParams;
 
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO refactor in V2 api, remove redundant path: /get-transactions
-    return await axios.get(`${fetchURL}/transactions/get-transactions`, {
+    return await httpClient.get(`/transactions/get-transactions`, {
         params: {
             date: date ? date : undefined,
             offset: offset ? offset : undefined,

--- a/src/api/transactions/fetchTransactionsCount.ts
+++ b/src/api/transactions/fetchTransactionsCount.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import { isValidURL } from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchTransactionsCount(timeFrame?: string | undefined, date?: Date | null | undefined | string) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO timeFrame should be optional — if there's no timeframe, it returns the total number of transactions
     // TODO refactor away from this route to passing query params to transactions route, totalTransactionsCount
-    return await axios.get(`${fetchURL}/transactions/get-transactions-count`, {
+    return await httpClient.get(`/transactions/get-transactions-count`, {
         params: {
             timeFrame: timeFrame,
             date: date

--- a/src/api/transactions/fetchWeekSummary.ts
+++ b/src/api/transactions/fetchWeekSummary.ts
@@ -1,17 +1,9 @@
-import axios from 'axios'
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {WeekSummary} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchWeekSummary(week: string): Promise<Array<WeekSummary>> {
-
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid')
-    }
-
-    return await axios
-        .get(`${fetchURL}/transactions/get-week-summary`, {
+    return await httpClient
+        .get(`/transactions/get-week-summary`, {
             params: {
                 week
             }

--- a/src/api/transactions/fetchWeeks.ts
+++ b/src/api/transactions/fetchWeeks.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {WeekYear} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchWeeks(): Promise<Array<WeekYear>> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-weeks`)
+    return await httpClient.get(`/transactions/get-weeks`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/fetchWeeksOfMonth.ts
+++ b/src/api/transactions/fetchWeeksOfMonth.ts
@@ -1,14 +1,7 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 
 export async function fetchWeeksOfMonth(monthString: string) {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-weeks-of-month`, {
+    return await httpClient.get(`/transactions/get-weeks-of-month`, {
         params: {
             month: monthString
         }

--- a/src/api/transactions/fetchYears.ts
+++ b/src/api/transactions/fetchYears.ts
@@ -1,15 +1,8 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {Year} from "@types";
 
 export async function fetchYears(): Promise<Array<Year>> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.get(`${fetchURL}/transactions/get-years`)
+    return await httpClient.get(`/transactions/get-years`)
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);

--- a/src/api/transactions/updateMemo.ts
+++ b/src/api/transactions/updateMemo.ts
@@ -1,20 +1,13 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
 import type {Memo} from "@types";
+import {httpClient} from "@api/httpClient";
 
 export async function updateMemo (memo: Partial<Memo>): Promise<Memo> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
     // TODO remove route from API Gateway. use '/memos/{memoId}' instead
-    return await axios.patch(`${fetchURL}/transactions/update-memo`, {
+    return await httpClient .patch(`/memos/update-memo`, {
         memo: memo
     })
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);
-            throw err;
         });
 }

--- a/src/api/transactions/updateMemoBudgetCategory.ts
+++ b/src/api/transactions/updateMemoBudgetCategory.ts
@@ -1,16 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {BudgetCategory, Memo} from "@types";
 
-// TODO remove: it's redundant. And, remove route from API Gateway.
 export async function updateMemoBudgetCategory(memo: Memo['name'], budgetCategory: string): Promise<BudgetCategory> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
-    return await axios.patch(`${fetchURL}/transactions/update-memo-budget-category`, {
+    // TODO remove: it's redundant. And, remove route from API Gateway.
+    return await httpClient.patch(`/transactions/update-memo-budget-category`, {
             memo: memo,
             budgetCategory: budgetCategory
         },
@@ -18,6 +11,5 @@ export async function updateMemoBudgetCategory(memo: Memo['name'], budgetCategor
         .then(res => res.data)
         .catch((err: Error) => {
             console.error('err:', err);
-            throw err;
         });
 }

--- a/src/api/transactions/updateTransaction.ts
+++ b/src/api/transactions/updateTransaction.ts
@@ -1,17 +1,9 @@
-import axios from "axios";
-import {isValidURL} from "@api/helpers/isValidURL";
+import {httpClient} from "@api/httpClient";
 import type {Transaction} from "@types";
 
-// should I be using Partial<Transaction> instead of Transaction?
 export async function updateTransaction(transaction: Partial<Transaction>): Promise<Transaction> {
-    const fetchURL = import.meta.env.VITE_APIGATEWAY_URL;
-
-    if (!isValidURL(fetchURL)) {
-        throw Error('url is not valid');
-    }
-
     // TODO remove route from API Gateway. use '/transactions/{transactionId}' instead
-    return await axios.patch(`${fetchURL}/transactions/update-transaction`, {
+    return await httpClient.patch(`/transactions/update-transaction`, {
         transaction: transaction
     })
         .then(res => res.data)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface AddressFields {
 }
 
 export type Transaction = {
+    id: number;
     transactionNumber: string;
     date: string;
     description?: string;
@@ -80,6 +81,7 @@ export interface PieChartData {
 }
 
 export interface Memo {
+    id: number;
     name: string
     recurring: boolean;
     necessary: boolean;


### PR DESCRIPTION
- Don't Repeat Yourself! 
- use a client to set a default URL just once, then import that client in the API methods, ya dum dum 
- adding an `id` field to the `Transaction` and `Memo` type