### PR TITLE
feat: update API route prefix from /api to /api/v1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,14 @@
 import { devConsole } from '@utils/devConsole'
 
 const LAMBDA_DEV_URL: string = 'http://127.0.0.1:3000'
-const LAMBDA_DEV_PROXY = '/api'
+const LAMBDA_DEV_PROXY = '/api/v1'
 const API_GATEWAY_URL = import.meta.env.VITE_APIGATEWAY_URL ?? ''
 
-// /api is the canonical route prefix. In DEV mode, the Vite proxy forwards
+// /api/v1 is the canonical route prefix. In DEV mode, the Vite proxy forwards
 // /api → 127.0.0.1:3000/api (same-origin, no CORS). In production, append
-// /api to the API Gateway URL so httpClient paths (/transactions, /memos, etc.)
-// resolve to /api/transactions, /api/memos, etc.
-let baseApiUrl = import.meta.env.DEV ? LAMBDA_DEV_PROXY : `${API_GATEWAY_URL}/api`
+// /api/v1 to the API Gateway URL so httpClient paths (/transactions, /memos, etc.)
+// resolve to /api/v1/transactions, /api/v1/memos, etc.
+let baseApiUrl = import.meta.env.DEV ? LAMBDA_DEV_PROXY : `${API_GATEWAY_URL}/api/v1`
 
 /**
  * Returns the current base API URL.
@@ -49,11 +49,11 @@ const initBaseApiUrl = async (): Promise<string> => {
       LAMBDA_DEV_PROXY,
     )
   } catch {
-    baseApiUrl = `${API_GATEWAY_URL}/api`
+    baseApiUrl = `${API_GATEWAY_URL}/api/v1`
     devConsole(
       'info',
       '[constants] Local dev server not reachable, falling back to:',
-      `${API_GATEWAY_URL}/api`,
+      `${API_GATEWAY_URL}/api/v1`,
     )
   } finally {
     clearTimeout(timeoutId)

--- a/src/test/e2e/helpers/e2eApiUrl.ts
+++ b/src/test/e2e/helpers/e2eApiUrl.ts
@@ -1,12 +1,12 @@
 /**
- * Pure URL helpers for Playwright route matching (Vite /api proxy vs direct paths).
+ * Pure URL helpers for Playwright route matching (Vite /api/v1 proxy vs direct paths).
  */
 
-/** Path after optional /api prefix (Vite dev proxy uses /api → backend). */
+/** Path after optional /api/v1 prefix (Vite dev proxy uses /api/v1 → backend). */
 export function apiPathname(url: URL): string {
   const { pathname } = url
-  if (pathname === '/api' || pathname.startsWith('/api/')) {
-    return pathname === '/api' ? '/' : pathname.slice('/api'.length)
+  if (pathname === '/api/v1' || pathname.startsWith('/api/v1/')) {
+    return pathname === '/api/v1' ? '/' : pathname.slice('/api/v1'.length)
   }
   return pathname
 }

--- a/src/test/unit/e2eApiUrl.spec.ts
+++ b/src/test/unit/e2eApiUrl.spec.ts
@@ -3,12 +3,12 @@ import { apiPathname, isExecuteApiUrl } from '@test/e2e/helpers/e2eApiUrl.ts'
 
 describe('e2eApiUrl', () => {
   describe('apiPathname', () => {
-    it('strips /api prefix', () => {
-      expect(apiPathname(new URL('http://localhost:5173/api/memos'))).toBe('/memos')
+    it('strips /api/v1 prefix', () => {
+      expect(apiPathname(new URL('http://localhost:5173/api/v1/memos'))).toBe('/memos')
     })
 
-    it('maps bare /api to /', () => {
-      expect(apiPathname(new URL('http://localhost:5173/api'))).toBe('/')
+    it('maps bare /api/v1 to /', () => {
+      expect(apiPathname(new URL('http://localhost:5173/api/v1'))).toBe('/')
     })
 
     it('leaves non-proxy paths unchanged', () => {
@@ -23,8 +23,8 @@ describe('e2eApiUrl', () => {
       ).toBe(true)
     })
 
-    it('matches localhost /api/memos (Vite proxy base URL)', () => {
-      expect(isExecuteApiUrl(new URL('http://localhost:5173/api/memos?limit=20'))).toBe(true)
+    it('matches localhost /api/v1/memos (Vite proxy base URL)', () => {
+      expect(isExecuteApiUrl(new URL('http://localhost:5173/api/v1/memos?limit=20'))).toBe(true)
     })
 
     it('matches localhost /memos without /api', () => {

--- a/src/test/unit/initBaseApiUrl.spec.ts
+++ b/src/test/unit/initBaseApiUrl.spec.ts
@@ -27,7 +27,9 @@ describe('initBaseApiUrl', () => {
     const { initBaseApiUrl, getBaseApiUrl } = await import('@constants')
     await initBaseApiUrl()
 
-    expect(getBaseApiUrl()).toBe('https://gw.example.execute-api.us-east-1.amazonaws.com/Stage/api/v1')
+    expect(getBaseApiUrl()).toBe(
+      'https://gw.example.execute-api.us-east-1.amazonaws.com/Stage/api/v1',
+    )
   })
 
   it('defaults baseApiUrl to /api/v1 when VITE_APIGATEWAY_URL is unset (production)', async () => {

--- a/src/test/unit/initBaseApiUrl.spec.ts
+++ b/src/test/unit/initBaseApiUrl.spec.ts
@@ -27,19 +27,19 @@ describe('initBaseApiUrl', () => {
     const { initBaseApiUrl, getBaseApiUrl } = await import('@constants')
     await initBaseApiUrl()
 
-    expect(getBaseApiUrl()).toBe('https://gw.example.execute-api.us-east-1.amazonaws.com/Stage/api')
+    expect(getBaseApiUrl()).toBe('https://gw.example.execute-api.us-east-1.amazonaws.com/Stage/api/v1')
   })
 
-  it('defaults baseApiUrl to /api when VITE_APIGATEWAY_URL is unset (production)', async () => {
+  it('defaults baseApiUrl to /api/v1 when VITE_APIGATEWAY_URL is unset (production)', async () => {
     vi.stubEnv('VITE_APIGATEWAY_URL', undefined as unknown as string)
     vi.stubEnv('DEV', false)
 
     const { getBaseApiUrl } = await import('@constants')
 
-    expect(getBaseApiUrl()).toBe('/api')
+    expect(getBaseApiUrl()).toBe('/api/v1')
   })
 
-  it('defaults fallback to /api when VITE_APIGATEWAY_URL is unset (dev, proxy down)', async () => {
+  it('defaults fallback to /api/v1 when VITE_APIGATEWAY_URL is unset (dev, proxy down)', async () => {
     vi.stubEnv('VITE_APIGATEWAY_URL', undefined as unknown as string)
     vi.stubEnv('DEV', true)
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connection refused')))
@@ -47,10 +47,10 @@ describe('initBaseApiUrl', () => {
     const { initBaseApiUrl, getBaseApiUrl } = await import('@constants')
     await initBaseApiUrl()
 
-    expect(getBaseApiUrl()).toBe('/api')
+    expect(getBaseApiUrl()).toBe('/api/v1')
   })
 
-  it('keeps /api when proxy HEAD succeeds', async () => {
+  it('keeps /api/v1 when proxy HEAD succeeds', async () => {
     vi.stubEnv('DEV', true)
     vi.stubGlobal(
       'fetch',
@@ -63,6 +63,6 @@ describe('initBaseApiUrl', () => {
     const { initBaseApiUrl, getBaseApiUrl } = await import('@constants')
     await initBaseApiUrl()
 
-    expect(getBaseApiUrl()).toBe('/api')
+    expect(getBaseApiUrl()).toBe('/api/v1')
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,7 +68,7 @@ export default defineConfig(async () => {
       host: 'localhost',
       port: 5173,
       proxy: {
-        '/api': {
+        '/api/v1': {
           target: 'http://127.0.0.1:3000',
           changeOrigin: true,
         },


### PR DESCRIPTION
## Summary
- Update API route prefix from `/api` to `/api/v1` to match backend versioned invocation URL.
- Vite dev proxy now forwards `/api/v1/*` → `127.0.0.1:3000/api/v1/*`.
- Production `baseApiUrl` resolves to `${API_GATEWAY_URL}/api/v1`.
- E2e URL helpers strip `/api/v1` prefix for Playwright route matching.
- Unit tests updated for all affected paths.

## Test plan
- [x] `initBaseApiUrl` unit tests pass (4/4)
- [x] `e2eApiUrl` unit tests pass (7/7)
- [ ] Verify local dev proxy forwards `/api/v1/*` requests correctly
- [ ] CI Playwright tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)