### PR TITLE
fix: reactive memo query keys + correct updateUser request

### DIFF
--- a/src/api/hooks/memos/useMemo.ts
+++ b/src/api/hooks/memos/useMemo.ts
@@ -5,8 +5,6 @@ import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 
 export default function useMemo(memoId: MaybeRefOrGetter<number>) {
   const memoIdValue = computed(() => toValue(memoId))
-  const memoIdIsNeitherUndefinedNorNull =
-    memoIdValue.value !== undefined && memoIdValue.value !== null
 
   return useQuery({
     queryKey: computed(() => ['memo', memoIdValue.value]),
@@ -14,7 +12,7 @@ export default function useMemo(memoId: MaybeRefOrGetter<number>) {
       return await fetchMemo(memoIdValue.value)
     },
     refetchOnWindowFocus: false,
-    enabled: memoIdIsNeitherUndefinedNorNull,
+    enabled: computed(() => memoIdValue.value !== undefined && memoIdValue.value !== null),
     retry: 1,
     retryDelay: 50,
     staleTime: 0,

--- a/src/api/hooks/memos/useMemos.ts
+++ b/src/api/hooks/memos/useMemos.ts
@@ -28,10 +28,10 @@ export function useMemos(params: UseMemosParams = {}) {
 
   return useInfiniteQuery<Array<Memo>>({
     initialPageParam: 0,
-    queryKey: [
+    queryKey: computed(() => [
       'memos',
       { limit: limit.value, date: date.value, timeFrame: timeFrame.value, count: count.value },
-    ],
+    ]),
     queryFn: async ({ pageParam = 0 }) => {
       const queryParams: MemoQueryParams = {
         limit: limit.value,

--- a/src/api/users/updateUser.ts
+++ b/src/api/users/updateUser.ts
@@ -2,9 +2,11 @@ import type { User } from '@types'
 import { httpClient } from '@api/httpClient.ts'
 
 export async function updateUser(user: Partial<User>) {
-  const response = await httpClient.put(`/users/${user.username}`, {
-    body: user,
-  })
+  if (user.id === undefined || user.id === null) {
+    throw new Error('updateUser requires user.id')
+  }
+
+  const response = await httpClient.put(`/users/${user.id}`, { user })
 
   if (!response) {
     throw new Error('Failed to update user')

--- a/src/test/api/users/updateUser.test.ts
+++ b/src/test/api/users/updateUser.test.ts
@@ -1,0 +1,43 @@
+import { updateUser } from '@api/users/updateUser'
+import { vi, test, describe, afterEach, expect } from 'vitest'
+import type { User } from '@types'
+
+vi.mock('@api/httpClient', () => ({
+  httpClient: {
+    put: vi.fn(),
+  },
+}))
+
+import { httpClient } from '@api/httpClient'
+
+const mockPut = vi.mocked(httpClient.put)
+
+describe('updateUser', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('PUTs to /users/:id with the { user } envelope and returns response data', async () => {
+    const updated = { id: 42, username: 'ada', email: 'ada@example.com' }
+    mockPut.mockResolvedValue({ data: updated })
+
+    const user: Partial<User> = { id: 42, username: 'ada', email: 'ada@example.com' }
+    const result = await updateUser(user)
+
+    expect(mockPut).toHaveBeenCalledWith('/users/42', { user })
+    expect(result).toEqual(updated)
+  })
+
+  test('throws when user.id is missing (avoids PUT /users/undefined)', async () => {
+    const user: Partial<User> = { username: 'ada', email: 'ada@example.com' }
+
+    await expect(updateUser(user)).rejects.toThrow('updateUser requires user.id')
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+
+  test('throws when the request returns a falsy response', async () => {
+    mockPut.mockResolvedValue(undefined)
+
+    await expect(updateUser({ id: 1, username: 'x' })).rejects.toThrow('Failed to update user')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes three pre-existing **correctness bugs** in the API/data layer, surfaced by a codebase audit. All are on `main` (independent of any in-flight feature work) and are low-risk, isolated changes.

| # | Bug | Effect |
|---|-----|--------|
| `useMemos` | Infinite-query `queryKey` was a plain array with `.value` read once at setup | Key never changed → memo list **never refetched** when date/timeFrame/count/limit changed. Now wrapped in `computed()`, matching every sibling hook. |
| `useMemo` | `enabled` was a boolean evaluated once | A query starting with a null/undefined id could **never enable** once the id became valid. Now a `computed()`. |
| `updateUser` | Sent `{ body: user }` (server expects `{ user }`) and built the URL from `user.username` instead of `id` | Wrong envelope + `PUT /users/undefined` on a `Partial<User>`. Now uses `{ user }` + `/users/:id`, matching `createUser`/`getUser`/`deleteUser`, and guards that `id` exists. |

## Testing
- `npm run type-check` ✅
- Existing api/memo unit tests ✅ (63 passed)
- Added `src/test/api/users/updateUser.test.ts` (envelope/URL, missing-id guard, failure) ✅
- ESLint clean ✅

## Notes
Two related data-layer bugs from the same audit (`useTransactionsCount` non-reactive key, and the `daySummary`↔`day-summary` invalidation mismatch) are **not** included here because they live in files currently modified/untracked in a feature branch's working tree — they'll be fixed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)