### PR TITLE
fix: stop D3 chart tooltip/tippy memory leaks and redundant pie redraws

### DIFF
--- a/src/components/charts/LineChart.vue
+++ b/src/components/charts/LineChart.vue
@@ -33,10 +33,13 @@ const width = ref(0)
 const height = ref(150)
 
 let resizeObserver: ResizeObserver | null = null
+let destroyChartTooltips: (() => void) | null = null
 
 const clearChart = () => {
+  // Destroy tippy instances before dropping their SVG nodes to avoid leaking poppers.
+  destroyChartTooltips?.()
+  destroyChartTooltips = null
   if (svg.value) {
-    // Clear all child elements
     svg.value.innerHTML = ''
   }
 }
@@ -49,7 +52,7 @@ const createChart = async () => {
   try {
     clearChart()
     await nextTick()
-    createLineChart(svg.value, props.summaries, props.handleOnClickSelection)
+    destroyChartTooltips = createLineChart(svg.value, props.summaries, props.handleOnClickSelection)
   } catch (error) {
     devConsole('error', 'Error creating line chart:', error)
   }

--- a/src/components/charts/createLineChart.ts
+++ b/src/components/charts/createLineChart.ts
@@ -8,8 +8,12 @@ export const createLineChart = (
   el: unknown,
   summaries: (SummaryTypeBase | DailyInterval)[],
   onDateSelected: (date: string) => void,
-) => {
+): (() => void) => {
   const svgElement = el as SVGSVGElement
+
+  // Tippy poppers attach to document.body and survive SVG clearing; collect
+  // them so the caller can destroy them before redraw/unmount.
+  const tippyInstances: { destroy: () => void }[] = []
 
   // if there's already an SVG element, destroy it utterly
   if (svgElement) {
@@ -121,7 +125,7 @@ export const createLineChart = (
       onDateSelected(dateString)
     })
     .each(function (d) {
-      useTippy(this, {
+      const { destroy } = useTippy(this, {
         content: `${d3.utcFormat('%Y-%m-%d')(d.date)}<br>$${d?.total_debit?.toFixed(2)}`,
         allowHTML: true,
         theme: 'translucent',
@@ -133,5 +137,11 @@ export const createLineChart = (
           instance.popper.setAttribute('data-testid', 'line-chart-tooltip')
         },
       })
+      tippyInstances.push({ destroy })
     })
+
+  return () => {
+    tippyInstances.forEach((t) => t.destroy())
+    tippyInstances.length = 0
+  }
 }

--- a/src/components/transactions/charts/BudgetCategoryPieChart.vue
+++ b/src/components/transactions/charts/BudgetCategoryPieChart.vue
@@ -89,7 +89,7 @@
 <script setup lang="ts">
 import { devConsole } from '@utils/devConsole'
 
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { ElSkeleton, ElSkeletonItem, ElSpace, ElText, ElSwitch } from 'element-plus'
 import * as d3 from 'd3'
 import type { BudgetCategorySummary } from '@types'
@@ -210,6 +210,7 @@ const drawChart = async () => {
 
   const svg = d3.select(svgRef.value)
   svg.selectAll('*').remove() // Clear previous chart
+  d3.select('body').selectAll('.pie-chart-tooltip').remove() // Remove any stale tooltip
 
   const { width, height, margin } = chartDimensions.value
   const chartWidth = width - margin.left - margin.right
@@ -413,57 +414,18 @@ const drawChart = async () => {
   }
 }
 
-// Watch for data changes and redraw
-watch(
-  () => props.data,
-  async (newData, oldData) => {
-    devConsole('log', 'PieChart: Data prop changed', {
-      newDataLength: newData?.length || 0,
-      oldDataLength: oldData?.length || 0,
-      hasNewData: !!newData?.length,
-      isLoading: props.isLoading,
-    })
+const redraw = async () => {
+  if (props.isLoading || !props.data?.length) return
+  await nextTick()
+  drawChart()
+}
 
-    if (!props.isLoading && newData && newData.length > 0) {
-      await nextTick()
-      drawChart()
-    }
-  },
-  { immediate: true, deep: true },
-)
+watch([() => props.data, () => props.isLoading], redraw, { deep: true })
 
-// Also watch for loading state changes
-watch(
-  () => props.isLoading,
-  async (isLoading) => {
-    devConsole('log', 'PieChart: Loading state changed', { isLoading })
+onMounted(redraw)
 
-    if (!isLoading && props.data && props.data.length > 0) {
-      await nextTick()
-      drawChart()
-    }
-  },
-  { immediate: true },
-)
-
-// Watch for legend visibility changes
-watch(
-  () => localShowLegend.value,
-  () => {
-    // No need to redraw chart, just toggle legend visibility
-  },
-)
-
-onMounted(async () => {
-  devConsole('log', 'PieChart: Component mounted', {
-    hasData: !!props.data?.length,
-    isLoading: props.isLoading,
-  })
-
-  if (!props.isLoading && props.data && props.data.length > 0) {
-    await nextTick()
-    drawChart()
-  }
+onUnmounted(() => {
+  d3.select('body').selectAll('.pie-chart-tooltip').remove()
 })
 </script>
 


### PR DESCRIPTION
## Summary

Fixes the D3 memory leaks from the codebase audit. All three files were clean on `main`.

| Component | Leak | Fix |
|-----------|------|-----|
| `createLineChart.ts` / `LineChart.vue` | A `useTippy` instance is created per dot but never destroyed — `clearChart()` only did `innerHTML = ''`, so tippy poppers accumulated on `document.body` on every redraw, resize, and loading toggle. | `createLineChart` now returns a cleanup fn; `LineChart` destroys the instances before each redraw and in `onBeforeUnmount`. |
| `BudgetCategoryPieChart.vue` | `drawChart()` appended a `.pie-chart-tooltip` div to `<body>` every call with no cleanup — one orphaned tooltip per redraw, and none removed on unmount (there was no `onUnmounted`). | Stale tooltips removed before each draw; `onUnmounted` cleans up. |

## Also
- Collapsed the pie chart's two `{ immediate: true }` watchers + `onMounted` draw (which redrew 2–3× on initial render) into a single `[data, isLoading]` watcher plus one `onMounted` draw.
- Dropped the leftover `devConsole` debug logging in those watchers/hooks.

## Testing
- `npm run type-check` ✅
- Full unit suite: 216 passed ✅
- ESLint clean ✅
- e2e (charts are covered there) runs in CI — now unblocked by the Node-22 fix in #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)