### PR TITLE
fix: component reactivity bugs (edit form prop mutation, lost reactivity in address & summaries)

### DIFF
--- a/src/api/hooks/memos/useMemoSummary.ts
+++ b/src/api/hooks/memos/useMemoSummary.ts
@@ -2,12 +2,17 @@ import { useQuery } from '@tanstack/vue-query'
 import type { UseQueryReturnType } from '@tanstack/vue-query'
 import { fetchMemoSummary } from '@api/memos/fetchMemoSummary.ts'
 import type { Memo, MemoSummary } from '@types'
+import { computed, type MaybeRefOrGetter, toValue } from 'vue'
 
-export default function useMemoSummary(memoId: Memo['id']): UseQueryReturnType<MemoSummary, Error> {
+export default function useMemoSummary(
+  memoId: MaybeRefOrGetter<Memo['id']>,
+): UseQueryReturnType<MemoSummary, Error> {
+  const memoIdValue = computed(() => toValue(memoId))
+
   return useQuery({
-    queryKey: ['memoSummary', memoId],
-    queryFn: () => fetchMemoSummary(memoId),
+    queryKey: computed(() => ['memoSummary', memoIdValue.value]),
+    queryFn: () => fetchMemoSummary(memoIdValue.value),
     refetchOnWindowFocus: false,
-    enabled: !!memoId,
+    enabled: computed(() => !!memoIdValue.value),
   })
 }

--- a/src/components/address/AddressResults.vue
+++ b/src/components/address/AddressResults.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed } from 'vue'
 import AddressResultFieldsTable from './AddressResultFieldsTable.vue'
 import CoordinatesTable from './CoordinatesTable.vue'
 
@@ -56,19 +56,7 @@ const props = defineProps<{
   message: AddressResponse[]
 }>()
 
-const data = ref(props.message)
-computed(() => {
-  if (props.message && props.message.length > 0) {
-    const addresses = props.message.map((item: AddressResponse) => item.address)
-    return addresses.map((address) => {
-      return Object.entries(address).map(([key, value]) => {
-        return { key, value }
-      })
-    })
-  } else {
-    return [[]]
-  }
-})
+const data = computed(() => props.message)
 const columns = [
   { prop: 'display_name', label: 'Display Name' },
   { prop: 'coordinates', label: 'Coordinates' },

--- a/src/components/memos/MemoSummaryTable.vue
+++ b/src/components/memos/MemoSummaryTable.vue
@@ -132,7 +132,7 @@ const {
   isLoading: memoLoading,
   isFetching: memoFetching,
   refetch: refetchMemo,
-} = useMemo(memoId.value)
+} = useMemo(memoId)
 
 // Fetch memo summary data
 const {
@@ -141,7 +141,7 @@ const {
   isLoading: summaryLoading,
   isError,
   error,
-} = useMemoSummary(memoId.value)
+} = useMemoSummary(memoId)
 
 const { mutate } = mutateMemo()
 

--- a/src/components/transactions/TransactionEditForm.vue
+++ b/src/components/transactions/TransactionEditForm.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { type PropType, reactive, ref, watch, computed } from 'vue'
+import { type PropType, reactive, ref, toRaw, watch, computed } from 'vue'
 import type {
   Transaction,
   TransactionFormFields,
@@ -61,7 +61,8 @@ const emit = defineEmits<{
 }>()
 
 const formRef = ref<InstanceType<typeof ElForm> | null>(null)
-const transaction = reactive<Transaction>(props.transaction as Transaction)
+// Clone so edits don't mutate the prop (which may be a cached vue-query object).
+const transaction = reactive<Transaction>(structuredClone(toRaw(props.transaction)) as Transaction)
 
 // Budget category state - single source of truth
 const budgetCategoryState = ref<BudgetCategoryState>(

--- a/src/components/transactions/summaries/month/MonthlyAmountDebitTotal.vue
+++ b/src/components/transactions/summaries/month/MonthlyAmountDebitTotal.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { ElStatistic } from 'element-plus'
 import useSumAmountDebitByDate from '@api/hooks/transactions/useSumAmountDebitByDate.ts'
 import { useTransactionsStore } from '@stores/transactions.ts'
@@ -28,26 +28,10 @@ import AlertComponent from '@components/shared/AlertComponent.vue'
 const store = useTransactionsStore()
 const selectedMonth = computed(() => store.getSelectedMonth)
 
-const { data, isLoading, isFetching, isRefetching, isError, error, refetch } =
-  useSumAmountDebitByDate('month', selectedMonth.value)
-
-const dataItems = computed(() => data.value)
-
-const statisticValue = computed(() => {
-  if (!dataItems.value) {
-    return 0
-  } else {
-    return dataItems.value?.[0]?.total_amount_debit
-  }
-})
-
-watch(
-  () => selectedMonth,
-  (newValue) => {
-    if (newValue) {
-      refetch()
-    }
-  },
-  { immediate: true },
+const { data, isLoading, isFetching, isRefetching, isError, error } = useSumAmountDebitByDate(
+  'month',
+  selectedMonth,
 )
+
+const statisticValue = computed(() => data.value?.[0]?.total_amount_debit ?? 0)
 </script>

--- a/src/components/transactions/summaries/week/WeeklyAmountDebitTotal.vue
+++ b/src/components/transactions/summaries/week/WeeklyAmountDebitTotal.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 import { ElStatistic } from 'element-plus'
 import useSumAmountDebitByDate from '@api/hooks/transactions/useSumAmountDebitByDate.ts'
 import { useTransactionsStore } from '@stores/transactions.ts'
@@ -26,22 +26,14 @@ import AlertComponent from '@components/shared/AlertComponent.vue'
 const store = useTransactionsStore()
 const selectedWeek = computed(() => store.getSelectedWeek)
 
-const { data, isLoading, isFetching, isRefetching, isError, error, refetch } =
-  useSumAmountDebitByDate('week', selectedWeek.value)
+const { data, isLoading, isFetching, isRefetching, isError, error } = useSumAmountDebitByDate(
+  'week',
+  selectedWeek,
+)
 
 const weekTotalAmountDebit = computed(() => {
   return data?.value?.[0]?.total_amount_debit ?? 0
 })
-
-watch(
-  () => selectedWeek,
-  (newValue) => {
-    if (newValue) {
-      refetch()
-    }
-  },
-  { immediate: true },
-)
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Summary

Fixes the component reactivity/correctness bugs from the audit. All files were clean on `main`.

| Component | Bug | Fix |
|-----------|-----|-----|
| `TransactionEditForm.vue` | `reactive(props.transaction)` wrapped the prop object itself; edits and the external-change watcher's `Object.assign` mutated the caller's object — the **cached vue-query object** when opened from `TransactionEditPage`. | Clone: `reactive(structuredClone(toRaw(props.transaction)))`. |
| `AddressResults.vue` | `const data = ref(props.message)` snapshotted the prop once → table never updated on refetch. Plus an orphaned `computed()` whose result was discarded. | `computed(() => props.message)`; deleted the dead block. |
| `MemoSummaryTable.vue` | Passed `memoId.value` (a frozen number) to `useMemo`/`useMemoSummary` → navigating between memos showed stale data. | Pass the reactive getter `memoId`. |
| `useMemoSummary.ts` | Took a plain number with a static key & `enabled` → couldn't react to id changes. | Accept `MaybeRefOrGetter`, reactive `queryKey` + `enabled` (matches sibling hooks). |
| `Weekly` / `MonthlyAmountDebitTotal.vue` | Passed `selected{Week,Month}.value` (frozen) **and** had `watch(() => selectedRef, …)` that watched the ref's identity and never fired. | Pass the reactive computed so the hook's key drives refetch; removed the dead watch + a pass-through computed. |

## Testing
- `npm run type-check` ✅
- Full unit suite: 216 passed ✅ (incl. `MemoSummaryTable` and `AddressResults` component tests)
- ESLint clean ✅
- e2e runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)