### PR TITLE
refactor: drop redundant refetch watchers in BudgetCategorySummaries

### DIFF
--- a/src/api/hooks/budgetCategories/useBudgetCategorySummary.ts
+++ b/src/api/hooks/budgetCategories/useBudgetCategorySummary.ts
@@ -2,44 +2,23 @@ import { useQuery } from '@tanstack/vue-query'
 import { fetchTransactions } from '@api/transactions/fetchTransactions.ts'
 import type { Timeframe } from '@types'
 import { computed, type MaybeRefOrGetter, toValue } from 'vue'
-import { devConsole } from '@utils/devConsole'
 
 export const useBudgetCategorySummary = (
   timeFrame: MaybeRefOrGetter<Timeframe>,
   date: MaybeRefOrGetter<string>,
 ) => {
-  // Convert to reactive values
   const reactiveTimeFrame = computed(() => toValue(timeFrame))
   const reactiveDate = computed(() => toValue(date))
 
   return useQuery({
     queryKey: ['budget-category-summary', reactiveTimeFrame, reactiveDate],
-    queryFn: () => {
-      const currentTimeFrame = reactiveTimeFrame.value
-      const currentDate = reactiveDate.value
-
-      devConsole('log', 'useBudgetCategorySummary: Fetching data', {
-        timeFrame: currentTimeFrame,
-        date: currentDate,
-      })
-
-      return fetchTransactions({
+    queryFn: () =>
+      fetchTransactions({
         budgetCategoryHierarchySum: true,
-        timeFrame: currentTimeFrame,
-        date: currentDate,
-      })
-    },
-    refetchOnWindowFocus: false,
-    enabled: computed(() => {
-      const hasTimeFrame = !!reactiveTimeFrame.value
-      const hasDate = !!reactiveDate.value
-      devConsole('log', 'useBudgetCategorySummary: Query enabled check', {
-        hasTimeFrame,
-        hasDate,
         timeFrame: reactiveTimeFrame.value,
         date: reactiveDate.value,
-      })
-      return hasTimeFrame && hasDate
-    }),
+      }),
+    refetchOnWindowFocus: false,
+    enabled: computed(() => !!reactiveTimeFrame.value && !!reactiveDate.value),
   })
 }

--- a/src/components/transactions/summaries/BudgetCategorySummaries.vue
+++ b/src/components/transactions/summaries/BudgetCategorySummaries.vue
@@ -132,11 +132,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType, watch } from 'vue'
+import { computed, type PropType } from 'vue'
 import { useBudgetCategorySummary } from '@api/hooks/budgetCategories/useBudgetCategorySummary.ts'
 import StatisticComponent from '@components/shared/StatisticComponent.vue'
 import BudgetCategoryPieChart from '@components/transactions/charts/BudgetCategoryPieChart.vue'
-import { useTransactionsStore } from '@stores/transactions.ts'
 import type { BudgetCategorySummary, Timeframe } from '@types'
 import AlertComponent from '@components/shared/AlertComponent.vue'
 
@@ -155,9 +154,8 @@ const props = defineProps({
   },
 })
 
-const store = useTransactionsStore()
-
-// Create reactive computed properties that will trigger query updates
+// The query key is built from these reactive refs, so the summary refetches
+// automatically when the timeframe or date changes.
 const reactiveTimeFrame = computed(() => props.timeFrame)
 const reactiveDate = computed(() => props.date)
 
@@ -168,54 +166,7 @@ const handleRefetch = () => {
   refetch()
 }
 
-// Watch for changes in store values and force refetch
-watch(
-  () => store.getSelectedMonth,
-  (newMonth, oldMonth) => {
-    if (props.timeFrame === 'month' && newMonth !== oldMonth) {
-      refetch()
-    }
-  },
-  { immediate: false },
-)
-
-watch(
-  () => store.getSelectedWeek,
-  (newWeek, oldWeek) => {
-    if (props.timeFrame === 'week' && newWeek !== oldWeek) {
-      refetch()
-    }
-  },
-  { immediate: false },
-)
-
-watch(
-  () => store.getSelectedDay,
-  (newDay, oldDay) => {
-    if (props.timeFrame === 'day' && newDay !== oldDay) {
-      refetch()
-    }
-  },
-  { immediate: false },
-)
-// Also watch for changes to the props themselves
-watch(
-  () => [props.date, props.timeFrame],
-  ([newDate, newTimeFrame], [oldDate, oldTimeFrame]) => {
-    if (newDate !== oldDate || newTimeFrame !== oldTimeFrame) {
-      refetch()
-    }
-  },
-  { immediate: false },
-)
-
-const categorySummaries = computed((): BudgetCategorySummary[] => {
-  if (!data?.value) {
-    return []
-  }
-
-  return data.value.map((item: BudgetCategorySummary) => item)
-})
+const categorySummaries = computed((): BudgetCategorySummary[] => data.value ?? [])
 
 const hierarchicalSummaries = computed((): BudgetCategorySummary[] => {
   if (!categorySummaries.value.length) {


### PR DESCRIPTION
## Summary

`useBudgetCategorySummary` builds its query key from reactive `timeFrame`/`date` refs, so it already refetches when those change. The parents (`MonthSummaryTable`, `WeekSummaryTable`) pass those props from reactive store values (`selectedValue` / `selectedWeek`), so the component's four manual `watch(...) -> refetch()` handlers (`selectedMonth`/`Week`/`Day` + `[date, timeFrame]`) only produced **duplicate requests** for a single change.

- Removed the 4 redundant watchers (and the now-unused `watch` import + `store` ref). The manual retry button (`handleRefetch`) is kept.
- Simplified the identity-map computed `data.value.map(i => i)` → `data.value ?? []`.
- Removed leftover `devConsole` debug logging from `useBudgetCategorySummary` (it logged on every `enabled` re-evaluation and every fetch).

## Deliberately skipped from this audit cluster
- **`getWeekRange`** — *not a bug*. Luxon's `startOf('week')` defaults to Monday (ISO) and `fromObject({weekYear, weekNumber})` already lands there, so the Mon–Sun range is correct (the test confirms it).
- **`getIsoWeekNumber` UTC** — its test uses local-time date construction; forcing `{zone:'utc'}` would change the contract and break the test in non-UTC environments to fix only a theoretical boundary case. Not worth the risk.

## Testing
- Prettier ✅, ESLint ✅, type-check ✅, unit suite 203 passed ✅ (all four CI gates run locally this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)